### PR TITLE
docs(architecture): add process flow diagrams

### DIFF
--- a/docs/process_flow_diagrams/inventory-replenishment_management.puml
+++ b/docs/process_flow_diagrams/inventory-replenishment_management.puml
@@ -1,0 +1,33 @@
+@startuml Inventory and Replenishment Management
+title Flow Diagram: Inventory and Replenishment Management
+skinparam handwritten true
+
+|System|
+start
+:Monitors stock levels;
+repeat
+  :Checks if product stock is low;
+  if (Stock < Minimum Threshold?) then (Yes)
+    :Generates alert;
+    :Notifies Administrator;
+  else (No)
+    :Continues monitoring;
+  endif
+repeat while (Monitoring active) is (No, continue)
+
+|Administrator|
+:Receives alert and reviews stock;
+if (Create Purchase Order?) then (No)
+  :Dismisses alert;
+else (Yes)
+  :Creates Purchase Order;
+  |System|
+  :Sends order to supplier;
+endif
+
+|Administrator|
+:Registers receipt of goods;
+|System|
+:Updates product stock;
+stop
+@enduml

--- a/docs/process_flow_diagrams/place-deliver_order.puml
+++ b/docs/process_flow_diagrams/place-deliver_order.puml
@@ -1,0 +1,48 @@
+@startuml Place and Deliver an Order
+title Flow Diagram: Place and Deliver an Order
+skinparam handwritten true
+
+|Customer|
+start
+:Browses and adds products to cart;
+:Makes payment;
+
+|System|
+:Validates payment;
+if (Payment successful?) then (No)
+  :Notifies payment failure;
+  stop
+else (Yes)
+  :Reserves stock and notifies Administration;
+endif
+
+|Administrator|
+:Processes and assigns the order;
+|Logistics Staff|
+:Prepares and marks order as "In Transit";
+
+|System|
+:Updates status and notifies Customer;
+note right: Customer can track the shipment
+
+|Logistics Staff|
+:Makes the delivery;
+if (Delivery successful?) then (No)
+  :Reports an issue;
+  |System|
+  :Notifies Administrator and Customer;
+  |Administrator|
+  :Reassigns delivery or handles return;
+  stop
+else (Yes)
+  :Confirms delivery;
+endif
+
+|System|
+:Marks order as "Delivered";
+:Generates and sends invoice;
+|Customer|
+:Receives the product and invoice;
+
+stop
+@enduml

--- a/docs/process_flow_diagrams/return_management.puml
+++ b/docs/process_flow_diagrams/return_management.puml
@@ -1,0 +1,40 @@
+@startuml Return Management
+title Flow Diagram: Return Management
+skinparam handwritten true
+
+|Customer|
+start
+:Initiates return request;
+|System|
+:Registers request and notifies Administration;
+|Administrator|
+:Reviews request;
+if (Request approved?) then (Yes)
+  :Approves request;
+  |System|
+  :Generates and sends return shipping label;
+  |Customer|
+  :Packages and ships the product;
+else (No)
+  :Rejects request;
+  |System|
+  :Notifies Customer of rejection;
+  stop
+endif
+
+|Administrator|
+:Receives returned product;
+:Inspects product condition;
+if (Product in good condition?) then (Yes)
+  :Registers restocking;
+  |System|
+  :Updates product stock;
+  :Processes refund to Customer;
+else (No)
+  :Marks product as defective;
+endif
+
+|Customer|
+:Receives refund;
+stop
+@enduml


### PR DESCRIPTION
Add process flow diagrams of main processes:
- Place and Deliver an Order
- Inventory and Replenishment Management
- Return Management